### PR TITLE
Show the latest commit message by default

### DIFF
--- a/styles/github.user.css
+++ b/styles/github.user.css
@@ -269,4 +269,14 @@ body {
   display: none;
 }
 
+/* Show the latest commit message by default */
+.repository-content .Details:not(.Details--on) .Details-content--hidden {
+    display: block !important;
+}
+
+/* Remove the button that triggers showing the latest commit message */
+.repository-content .hidden-text-expander {
+    display: none !important;
+}
+
 }


### PR DESCRIPTION
Hey man,

This is cool. One thing I was missing is expanding the latest commit message and hiding the expand button, hence this patch.